### PR TITLE
[RFC] Refactoring project structure

### DIFF
--- a/rfcs/refactor_project_structure.md
+++ b/rfcs/refactor_project_structure.md
@@ -76,8 +76,8 @@ The `error`, `form`, `model` and `schema` directories isolate the modules
 implementation from the modules usage within the project.  
 
 #### Consequences
-+ We can make changes to individual modules without needing to make changes
-  anywhere else.
++ We can make changes to the underlying business logic, while keeping the
+  implementation clean.  
 
 ## `error/test/`, `form/test/`, `model/test/`, `schema/test/` 
 The `error/test/`, `form/test/`, `model/test/` and `schema/test/` directories
@@ -85,5 +85,5 @@ isolate the implementation of unit tests from the implementation of the
 module.
 
 #### Consequences
-+ The unit tests stay organized
++ The unit tests stay organized.
 + We know very quickly if a change made breaks an existing module.  

--- a/rfcs/refactor_project_structure.md
+++ b/rfcs/refactor_project_structure.md
@@ -29,20 +29,19 @@ This RFC proposes the following project structure:
 src
 ├── error             # error handling
 │   └── mod.rs
-├── form              # input form controllers
-│   ├── mod.rs
+├── for               # input form controllers
 │   ├── login.rs
+│   ├── mod.rs
 │   └── workshop.rs
-├── model             # data models
+├── mode              # data models
 │   ├── mod.rs
 │   └── user.rs
 ├── schema            # database schemas (not entirely sure if we need this module)
 │   ├── mod.rs
 │   └── user.rs
-├── tests             # tests
-│   └── mod.rs
 ├── lib.rs
-└── main.rs
+├── main.rs
+└── tests.rs
 ```
 
 ## Directory Structure Explanation

--- a/rfcs/refactor_project_structure.md
+++ b/rfcs/refactor_project_structure.md
@@ -16,52 +16,74 @@ new workshops is available but doesn't actually work.
 Right now adding new features or changing existing features is a messy process
 and changing or adding one feature impacts the implementation the others.  
 
-## Whats the Expected Outcome
+## Whats the Expected Outcome?
 The expected outcome of the proposed changes is a well structured project that
 is easy to navigate, build on and document without needing to change too much of
 whats already there.  
 
-# Guide-level explanation
-[guide-level-explanation]: #guide-level-explanation
+# Detailed Explanation
+[detailed-explaination]: #detail-explaination
 
-Explain the proposal as if it was already included in the language and you were teaching it to another Rust programmer. That generally means:
+This RFC proposes the following project structure:
+```
+src
+├── bin
+│   └── main.rs
+├── error
+│   ├── test
+│   │   └── mod.rs
+│   └── mod.rs
+├── form
+│   ├── test
+│   │   ├── mod.rs
+│   │   ├── login.rs
+│   │   └── workshop.rs
+│   ├── mod.rs
+│   ├── login.rs
+│   └── workshop.rs
+├── model
+│   ├── test
+│   │   ├── mod.rs
+│   │   └── user.rs
+│   ├── mod.rs
+│   └── user.rs
+├── schema
+│   ├── test
+│   │   ├── mod.rs
+│   │   └── user.rs
+│   ├── mod.rs
+│   └── user.rs
+└── lib.rs
 
-- Introducing new named concepts.
-- Explaining the feature largely in terms of examples.
-- Explaining how Rust programmers should *think* about the feature, and how it should impact the way they use Rust. It should explain the impact as concretely as possible.
-- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
-- If applicable, describe the differences between teaching this to existing Rust programmers and new Rust programmers.
+```
 
-For implementation-oriented RFCs (e.g. for compiler internals), this section should focus on how compiler contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
+## Directory Structure Explanation
+Using the proposed project structure we achieve high cohesion within each module
+and loose coupling within the project between each module.  This lets us add or
+remove modules as needed without drastically affecting the existing modules
+already present.  
 
-# Reference-level explanation
-[reference-level-explanation]: #reference-level-explanation
+## `bin/`
+The `bin` directory separates the actual executable from the rest of the
+project.   
 
-This is the technical portion of the RFC. Explain the design in sufficient detail that:
+#### Consequences
++ How we run the server and how we implement the server can now vary
+  independently.
 
-- Its interaction with other features is clear.
-- It is reasonably clear how the feature would be implemented.
-- Corner cases are dissected by example.
+## `error/`, `form/`, `model/`, `schema/`
+The `error`, `form`, `model` and `schema` directories isolate the modules
+implementation from the modules usage within the project.  
 
-The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+#### Consequences
++ We can make changes to individual modules without needing to make changes
+  anywhere else.
 
-# Drawbacks
-[drawbacks]: #drawbacks
+## `error/test/`, `form/test/`, `model/test/`, `schema/test/` 
+The `error/test/`, `form/test/`, `model/test/` and `schema/test/` directories
+isolate the implementation of unit tests from the implementation of the
+module.
 
-Why should we *not* do this?
-
-# Rationale and alternatives
-[alternatives]: #alternatives
-
-- Why is this design the best in the space of possible designs?
-- What other designs have been considered and what is the rationale for not choosing them?
-- What is the impact of not doing this?
-
-# Unresolved questions
-[unresolved]: #unresolved-questions
-
-- What parts of the design do you expect to resolve through the RFC process before this gets merged?
-- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
-- What related issues do you consider out of scope for this RFC that could be
-  addressed in the future independently of the solution that comes out of this
-  RFC?
+#### Consequences
++ The unit tests stay organized
++ We know very quickly if a change made breaks an existing module.  

--- a/rfcs/refactor_project_structure.md
+++ b/rfcs/refactor_project_structure.md
@@ -29,11 +29,11 @@ This RFC proposes the following project structure:
 src
 ├── error             # error handling
 │   └── mod.rs
-├── for               # input form controllers
+├── form              # input form controllers
 │   ├── login.rs
 │   ├── mod.rs
 │   └── workshop.rs
-├── mode              # data models
+├── model             # data models
 │   ├── mod.rs
 │   └── user.rs
 ├── schema            # database schemas (not entirely sure if we need this module)

--- a/rfcs/refactor_project_structure.md
+++ b/rfcs/refactor_project_structure.md
@@ -2,7 +2,7 @@
 [summary]: #summary
 
 This RFC describes a restructuring of the project into a library with separate modules for errors, forms,
-models and schemas.   
+models and schemas following the project layout [reference](https://doc.rust-lang.org/cargo/reference/manifest.html#the-project-layout).
 
 # Motivation
 [motivation]: #motivation
@@ -27,34 +27,22 @@ whats already there.
 This RFC proposes the following project structure:
 ```
 src
-├── bin
-│   └── main.rs
-├── error
-│   ├── test
-│   │   └── mod.rs
+├── error             # error handling
 │   └── mod.rs
-├── form
-│   ├── test
-│   │   ├── mod.rs
-│   │   ├── login.rs
-│   │   └── workshop.rs
+├── form              # input form controllers
 │   ├── mod.rs
 │   ├── login.rs
 │   └── workshop.rs
-├── model
-│   ├── test
-│   │   ├── mod.rs
-│   │   └── user.rs
+├── model             # data models
 │   ├── mod.rs
 │   └── user.rs
-├── schema
-│   ├── test
-│   │   ├── mod.rs
-│   │   └── user.rs
+├── schema            # database schemas (not entirely sure if we need this module)
 │   ├── mod.rs
 │   └── user.rs
-└── lib.rs
-
+├── tests             # tests
+│   └── mod.rs
+├── lib.rs
+└── main.rs
 ```
 
 ## Directory Structure Explanation
@@ -79,10 +67,9 @@ implementation from the modules usage within the project.
 + We can make changes to the underlying business logic, while keeping the
   implementation clean.  
 
-## `error/test/`, `form/test/`, `model/test/`, `schema/test/` 
-The `error/test/`, `form/test/`, `model/test/` and `schema/test/` directories
-isolate the implementation of unit tests from the implementation of the
-module.
+## `tests/`
+The tests directory isolates the implementation of unit tests from the
+implementation of the module.
 
 #### Consequences
 + The unit tests stay organized.

--- a/rfcs/refactor_project_structure.md
+++ b/rfcs/refactor_project_structure.md
@@ -1,0 +1,67 @@
+# Summary
+[summary]: #summary
+
+This RFC describes a restructuring of the project into a library with separate modules for errors, forms,
+models and schemas.   
+
+# Motivation
+[motivation]: #motivation
+
+## Why Restructure the Project?
+This project is the website for the rustbridge project and aims to make
+organizing and creating new rustbridge workshops easy.  Right now the website
+content is displayed and a bare-bones implementation of the submission form for
+new workshops is available but doesn't actually work.  
+
+Right now adding new features or changing existing features is a messy process
+and changing or adding one feature impacts the implementation the others.  
+
+## Whats the Expected Outcome
+The expected outcome of the proposed changes is a well structured project that
+is easy to navigate, build on and document without needing to change too much of
+whats already there.  
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Explain the proposal as if it was already included in the language and you were teaching it to another Rust programmer. That generally means:
+
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+- Explaining how Rust programmers should *think* about the feature, and how it should impact the way they use Rust. It should explain the impact as concretely as possible.
+- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
+- If applicable, describe the differences between teaching this to existing Rust programmers and new Rust programmers.
+
+For implementation-oriented RFCs (e.g. for compiler internals), this section should focus on how compiler contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+This is the technical portion of the RFC. Explain the design in sufficient detail that:
+
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- Corner cases are dissected by example.
+
+The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Rationale and alternatives
+[alternatives]: #alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What related issues do you consider out of scope for this RFC that could be
+  addressed in the future independently of the solution that comes out of this
+  RFC?


### PR DESCRIPTION
This RFC proposes changing the project structure to support better maintainability and growth of the project.  
 
[Rendered](https://github.com/rustbridge/rustbridge.io/blob/issue48-cleanup/rfcs/refactor_project_structure.md)